### PR TITLE
np - copy backend CRUD operations from team01 for menu items

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsController.java
@@ -1,0 +1,151 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * THis is a REST controller for UCSBDiningCommonsMenuItems
+ */
+
+@Tag(name = "UCSBDiningCommonsMenuItems")
+@RequestMapping("/api/ucsbdiningcommonsmenuitems")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemsController extends ApiController {
+
+  @Autowired
+  UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  /**
+   * List all UCSB Dining Commons Menu Items
+   * 
+   * @return an iterable of UCSBDiningCommonsMenuItems
+   */
+  @Operation(summary= "List all UCSB Dining Commons Menu Items")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItems() {
+      Iterable<UCSBDiningCommonsMenuItem> menuItems = ucsbDiningCommonsMenuItemRepository.findAll();
+      return menuItems;
+  }
+
+  /**
+   * Create a new UCSBDiningCommonsMenuItem
+   * 
+   * @param diningCommonsCode  the code of the dining common
+   * @param name          the name of the menu item
+   * @param station the station of the menu item
+   * @return the saved UCSB Dining Commons Menu Item
+   */
+  @Operation(summary= "Create a new dining commons menu item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+          @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+          @Parameter(name="name") @RequestParam String name,
+          @Parameter(name="station") @RequestParam String station)
+          throws JsonProcessingException {
+
+      UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = new UCSBDiningCommonsMenuItem();
+      ucsbDiningCommonsMenuItem.setDiningCommonsCode(diningCommonsCode);
+      ucsbDiningCommonsMenuItem.setName(name);
+      ucsbDiningCommonsMenuItem.setStation(station);
+
+      UCSBDiningCommonsMenuItem savedUCSBDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+      return savedUCSBDiningCommonsMenuItem;
+  }
+
+
+   /**
+     * Get a single menu item by id
+     * 
+     * @param id the id of the menu item
+     * @return a UCSBDiningCommonsMenuItem
+     */
+    @Operation(summary= "Get a single menu item")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        return ucsbDiningCommonsMenuItem;
+    }
+
+
+    /**
+     * Update a single menu item
+     * 
+     * @param id       id of the menu item to update
+     * @param incoming the new UCSBDiningCommonsMenuItem
+     * @return the updated UCSBDiningCommonsMenuItem object
+     */
+    @Operation(summary= "Update a single date")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+		ucsbDiningCommonsMenuItem.setDiningCommonsCode(incoming.getDiningCommonsCode());
+        ucsbDiningCommonsMenuItem.setName(incoming.getName());
+        ucsbDiningCommonsMenuItem.setStation(incoming.getStation());
+
+        ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+        return ucsbDiningCommonsMenuItem;
+    }
+
+	/**
+     * Delete a UCSB Dining Commons Menu Item
+     * 
+     * @param id the id of the menu item to delete
+     * @return a message indicating the menu item was deleted
+     */
+    @Operation(summary= "Delete a UCSBDiningCommonsMenuItem")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBDiningCommonsMenuItem(
+            @Parameter(name="id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        ucsbDiningCommonsMenuItemRepository.delete(ucsbDiningCommonsMenuItem);
+        return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
+    }
+
+
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a UCSBDiningCommonsMenuItem 
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitems")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDateRepository is a repository for UCSBDiningCommonsMenuItem entities.
+ */
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {
+
+}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItems-1",
+          "author": "nikunjparasar",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEMS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBDININGCOMMONSMENUITEMS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DINING_COMMONS_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEMS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemsControllerTest.java
@@ -1,0 +1,310 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemsController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemsControllerTest extends ControllerTestCase {
+  
+  @MockBean
+  UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  @MockBean
+  UserRepository userRepository;
+
+   @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsbdiningcommonsmenuitems/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsbdiningcommonsmenuitems/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+
+	@WithMockUser(roles = { "USER" })
+	@Test
+	public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+			// arrange
+			UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+				.diningCommonsCode("portola")
+				.name("burger")
+				.station("grill")
+				.build();
+
+
+			ArrayList<UCSBDiningCommonsMenuItem> expectedUCSBDiningCommonsMenuItems = new ArrayList<>();
+			expectedUCSBDiningCommonsMenuItems.addAll(Arrays.asList(ucsbDiningCommonsMenuItem1));
+
+			when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedUCSBDiningCommonsMenuItems);
+
+			// act
+			MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems/all"))
+							.andExpect(status().isOk()).andReturn();
+
+			// assert
+
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+			String expectedJson = mapper.writeValueAsString(expectedUCSBDiningCommonsMenuItems);
+			String responseString = response.getResponse().getContentAsString();
+			assertEquals(expectedJson, responseString);
+	}
+
+
+	@WithMockUser(roles = { "ADMIN", "USER" })
+	@Test
+	public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+			// arrange
+
+
+			UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+				.diningCommonsCode("portola")
+				.name("burger")
+				.station("grill")
+				.build();
+
+
+			when(ucsbDiningCommonsMenuItemRepository.save(eq(ucsbDiningCommonsMenuItem1))).thenReturn(ucsbDiningCommonsMenuItem1);
+
+			// act
+			MvcResult response = mockMvc.perform(
+							post("/api/ucsbdiningcommonsmenuitems/post?diningCommonsCode=portola&name=burger&station=grill")
+											.with(csrf()))
+							.andExpect(status().isOk()).andReturn();
+
+			// assert
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(eq(ucsbDiningCommonsMenuItem1));
+			String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem1);
+			String responseString = response.getResponse().getContentAsString();
+			assertEquals(expectedJson, responseString);
+	}
+
+
+	@Test
+	public void logged_out_users_cannot_get_by_id() throws Exception {
+			mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
+							.andExpect(status().is(403)); // logged out users can't get by id
+	}
+
+	@WithMockUser(roles = { "USER" })
+	@Test
+	public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+			// arrange
+
+			when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+			// act
+			MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
+							.andExpect(status().isNotFound()).andReturn();
+
+			// assert
+
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+			Map<String, Object> json = responseToJson(response);
+			assertEquals("EntityNotFoundException", json.get("type"));
+			assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
+	}
+
+
+	@WithMockUser(roles = { "USER" })
+	@Test
+	public void test_that_logged_in_user_can_get_by_id_when_the_id_does_exist() throws Exception {
+
+			// arrange
+			UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+				.diningCommonsCode("portola")
+				.name("burger")
+				.station("grill")
+				.build();
+
+			when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItem1));
+
+			// act
+			MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitems?id=7"))
+							.andExpect(status().isOk()).andReturn();
+
+			// assert
+
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+			String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem1);
+			String responseString = response.getResponse().getContentAsString();
+			assertEquals(expectedJson, responseString);
+
+	}
+
+
+	@WithMockUser(roles = { "ADMIN", "USER" })
+	@Test
+	public void admin_can_edit_an_existing_menu_item() throws Exception {
+			// arrange
+
+			UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItemOrig = UCSBDiningCommonsMenuItem.builder()
+				.diningCommonsCode("portola")
+				.name("burger")
+				.station("grill")
+				.build();
+
+			UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItemEdited = UCSBDiningCommonsMenuItem.builder()
+				.diningCommonsCode("dlg")
+				.name("cake")
+				.station("bakery")
+				.build();
+
+			
+			String requestBody = mapper.writeValueAsString(ucsbDiningCommonsMenuItemEdited);
+
+			when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItemOrig));
+
+			// act
+			MvcResult response = mockMvc.perform(
+							put("/api/ucsbdiningcommonsmenuitems?id=67")
+											.contentType(MediaType.APPLICATION_JSON)
+											.characterEncoding("utf-8")
+											.content(requestBody)
+											.with(csrf()))
+							.andExpect(status().isOk()).andReturn();
+
+			// assert
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(ucsbDiningCommonsMenuItemEdited); 
+			String responseString = response.getResponse().getContentAsString();
+			assertEquals(requestBody, responseString);
+	}
+
+	@WithMockUser(roles = { "ADMIN", "USER" })
+	@Test
+	public void admin_cannot_edit_menu_item_that_does_not_exist() throws Exception {
+			// arrange
+
+
+			UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItemEdited = UCSBDiningCommonsMenuItem.builder()
+				.diningCommonsCode("dlg")
+				.name("cake")
+				.station("bakery")
+				.build();
+
+			String requestBody = mapper.writeValueAsString(ucsbDiningCommonsMenuItemEdited);
+
+			when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+			// act
+			MvcResult response = mockMvc.perform(
+							put("/api/ucsbdiningcommonsmenuitems?id=67")
+											.contentType(MediaType.APPLICATION_JSON)
+											.characterEncoding("utf-8")
+											.content(requestBody)
+											.with(csrf()))
+							.andExpect(status().isNotFound()).andReturn();
+
+			// assert
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+			Map<String, Object> json = responseToJson(response);
+			assertEquals("UCSBDiningCommonsMenuItem with id 67 not found", json.get("message"));
+
+	}
+
+	@WithMockUser(roles = { "ADMIN", "USER" })
+	@Test
+	public void admin_can_delete_a_menu_item() throws Exception {
+			// arrange
+
+			UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+				.diningCommonsCode("dlg")
+				.name("cake")
+				.station("bakery")
+				.build();
+
+			when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItem1));
+
+			// act
+			MvcResult response = mockMvc.perform(
+							delete("/api/ucsbdiningcommonsmenuitems?id=15")
+											.with(csrf()))
+							.andExpect(status().isOk()).andReturn();
+
+			// assert
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(eq(ucsbDiningCommonsMenuItem1));
+
+			Map<String, Object> json = responseToJson(response);
+			assertEquals("UCSBDiningCommonsMenuItem with id 15 deleted", json.get("message"));
+	}
+
+
+	@WithMockUser(roles = { "ADMIN", "USER" })
+	@Test
+	public void admin_tries_to_delete_non_existant_menu_item_and_gets_right_error_message()
+					throws Exception {
+			// arrange
+
+			when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+			// act
+			MvcResult response = mockMvc.perform(
+							delete("/api/ucsbdiningcommonsmenuitems?id=15")
+											.with(csrf()))
+							.andExpect(status().isNotFound()).andReturn();
+
+			// assert
+			verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+			Map<String, Object> json = responseToJson(response);
+			assertEquals("UCSBDiningCommonsMenuItem with id 15 not found", json.get("message"));
+	}
+
+}


### PR DESCRIPTION
Closes #8 

in this PR, we copy over the entity, repository, controller, controller tests, and db migration file for the UCSBDiningCommonsMenuItems Table, from the previous project team01. 


To test:
1. fire up application on localhost or dokku
2. log in as admin
3. go to swagger
4. try each endpoint in UCSBDiningCommonsMenuItem

<img width="1476" alt="image" src="https://github.com/user-attachments/assets/20128a54-9947-426c-80de-4b20dca5ae92" />

