### PR TITLE
Timothy-  index menuitemreview page

### DIFF
--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.js
@@ -19,7 +19,7 @@ export default function MenuItemReviewsCreatePage({ storybook = false }) {
 
   const onSuccess = (menuitemreview) => {
     toast(
-      `New restaurant Created - id: ${menuitemreview.id} comments: ${menuitemreview.comments}`,
+      `New review created - id: ${menuitemreview.id} comments: ${menuitemreview.comments}`,
     );
   };
 
@@ -49,4 +49,3 @@ export default function MenuItemReviewsCreatePage({ storybook = false }) {
     </BasicLayout>
   );
 }
-

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsCreatePage.js
@@ -1,12 +1,52 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+import MenuItemReviewForm from "main/components/MenuItemReviews/MenuItemReviewForm";
 
-export default function MenuItemReviewsCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewsCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (menuitemreview) => ({
+    url: "/api/menuitemreviews/post",
+    method: "POST",
+    params: {
+      itemID: menuitemreview.itemId,
+      reviewerEmail: menuitemreview.reviewerEmail,
+      stars: menuitemreview.stars,
+      reviewDate: menuitemreview.dateReviewed,
+      comments: menuitemreview.comments,
+    },
+  });
+
+  const onSuccess = (menuitemreview) => {
+    toast(
+      `New restaurant Created - id: ${menuitemreview.id} comments: ${menuitemreview.comments}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/menuitemreviews/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreviews" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create new Menu Item Review</h1>
+        <MenuItemReviewForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );
 }
+

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsIndexPage.js
@@ -1,17 +1,46 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewTable from "main/components/MenuItemReviews/MenuItemReviewTable";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
 
 export default function MenuItemReviewsIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: menuItemReviews,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/menuitemreviews/all"],
+    { method: "GET", url: "/api/menuitemreviews/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/menuitemreviews/create"
+          style={{ float: "right" }}
+        >
+          Create MenuItemReviews
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/menuitemreviews/create">Create</a>
-        </p>
-        <p>
-          <a href="/menuitemreviews/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>MenuItemReviews</h1>
+        <MenuItemReviewTable menuItemReviews={menuItemReviews} currentUser={currentUser} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsIndexPage.js
@@ -40,7 +40,10 @@ export default function MenuItemReviewsIndexPage() {
       <div className="pt-2">
         {createButton()}
         <h1>MenuItemReviews</h1>
-        <MenuItemReviewTable menuItemReviews={menuItemReviews} currentUser={currentUser} />
+        <MenuItemReviewTable
+          menuItemReviews={menuItemReviews}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -7,7 +7,7 @@ export function onDeleteSuccess(message) {
 
 export function cellToAxiosParamsDelete(cell) {
   return {
-    url: "/api/menuItemReviews",
+    url: "/api/menuitemreviews",
     method: "DELETE",
     params: {
       id: cell.row.values.id,

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsCreatePage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsCreatePage.stories.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewsCreatePage from "main/pages/MenuItemReviews/MenuItemReviewsCreatePage";
+
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+export default {
+  title: "pages/MenuItemReviews/MenuItemReviewsCreatePage",
+  component: MenuItemReviewsCreatePage,
+};
+
+const Template = () => <MenuItemReviewsCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/menuitemreviews/post", () => {
+      return HttpResponse.json(menuItemReviewFixtures.oneMenuItemReview, {
+        status: 200,
+      });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsIndexPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsIndexPage.stories.js
@@ -69,4 +69,3 @@ ThreeItemsAdminUser.parameters = {
     }),
   ],
 };
-

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsIndexPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsIndexPage.stories.js
@@ -1,0 +1,72 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewsIndexPage from "main/pages/MenuItemReviews/MenuItemReviewsIndexPage";
+
+export default {
+  title: "pages/MenuItemReviews/MenuItemReviewsIndexPage",
+  component: MenuItemReviewsIndexPage,
+};
+
+const Template = () => <MenuItemReviewsIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuitemreviews/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/menuitemreviews/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeMenuItemReviews);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/menuitemreviews/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeMenuItemReviews);
+    }),
+    http.delete("/api/menuitemreviews", () => {
+      return HttpResponse.json(
+        { message: "Review deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};
+

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsCreatePage.test.js
@@ -1,17 +1,42 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import MenuItemReviewsCreatePage from "main/pages/MenuItemReviews/MenuItemReviewsCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("MenuItemReviewsCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +45,10 @@ describe("MenuItemReviewsCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +57,81 @@ describe("MenuItemReviewsCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("comments")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("on submit, makes request to backend, and redirects to /menuitemreviews", async () => {
+    const queryClient = new QueryClient();
+    const menuitemreview = {
+      id: 3,
+      itemId: 1,
+      reviewerEmail: "cgaucho@ucsb.edu",
+      stars: 5,
+      dateReviewed: "2025-05-08T11:05:00",
+      comments: "Great food!",
+    };
+
+    axiosMock.onPost("/api/menuitemreviews/post").reply(202, menuitemreview);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("itemId")).toBeInTheDocument();
+    });
+
+    const itemIdInput = screen.getByLabelText("itemId");
+    expect(itemIdInput).toBeInTheDocument();
+
+    const reviewerEmailInput = screen.getByLabelText("reviewerEmail");
+    expect(reviewerEmailInput).toBeInTheDocument();
+
+    const starsInput = screen.getByLabelText("stars");
+    expect(starsInput).toBeInTheDocument();
+
+    const dateReviewedInput = screen.getByLabelText(
+      "dateReviewed (iso format)",
+    );
+    expect(dateReviewedInput).toBeInTheDocument();
+
+    const commentsInput = screen.getByLabelText("comments");
+    expect(commentsInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(itemIdInput, { target: { value: 1 } });
+    fireEvent.change(reviewerEmailInput, {
+      target: { value: "cgaucho@ucsb.edu" },
+    });
+    fireEvent.change(starsInput, { target: { value: 5 } });
+    fireEvent.change(dateReviewedInput, {
+      target: { value: "2025-05-08T11:05:00" },
+    });
+    fireEvent.change(commentsInput, { target: { value: "Great food!" } });
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      itemID: "1",
+      reviewerEmail: "cgaucho@ucsb.edu",
+      stars: "5",
+      reviewDate: "2025-05-08T11:05",
+      comments: "Great food!",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toHaveBeenCalledWith(
+      "New review created - id: 3 comments: Great food!",
+    );
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/menuitemreviews" });
   });
 });

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsIndexPage.test.js
@@ -95,15 +95,15 @@ describe("MenuItemReviewsIndexPage tests", () => {
       "7",
     );
 
-    const createMenuItemReviewsButton = screen.queryByText("Create MenuItemReviews");
+    const createMenuItemReviewsButton = screen.queryByText(
+      "Create MenuItemReviews",
+    );
     expect(createMenuItemReviewsButton).not.toBeInTheDocument();
 
     const itemId = screen.getByText("1");
     expect(itemId).toBeInTheDocument();
 
-    const reviewerEmail = screen.getByText(
-      "cgaucho@ucsb.edu",
-    );
+    const reviewerEmail = screen.getByText("cgaucho@ucsb.edu");
     expect(reviewerEmail).toBeInTheDocument();
 
     const stars = screen.getByText("3");
@@ -112,9 +112,7 @@ describe("MenuItemReviewsIndexPage tests", () => {
     const dateReviewed = screen.getByText("2025-04-28T21:28:44.426");
     expect(dateReviewed).toBeInTheDocument();
 
-    const comments = screen.getByText(
-      "mac and cheese needs more cheese",
-    );
+    const comments = screen.getByText("mac and cheese needs more cheese");
     expect(comments).toBeInTheDocument();
 
     // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
@@ -158,7 +156,7 @@ describe("MenuItemReviewsIndexPage tests", () => {
     axiosMock
       .onGet("/api/menuitemreviews/all")
       .reply(200, menuItemReviewFixtures.threeMenuItemReviews);
-      axiosMock
+    axiosMock
       .onDelete("/api/menuitemreviews")
       .reply(200, "Review with id 5 was deleted");
 

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsIndexPage.test.js
@@ -1,15 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import MenuItemReviewsIndexPage from "main/pages/MenuItemReviews/MenuItemReviewsIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
 describe("MenuItemReviewsIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "MenuItemReviewTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +36,22 @@ describe("MenuItemReviewsIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
 
-    setupUserOnly();
-
-    // act
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/menuitemreviews/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +61,141 @@ describe("MenuItemReviewsIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create MenuItemReviews/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create MenuItemReviews/);
+    expect(button).toHaveAttribute("href", "/menuitemreviews/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
-    // assert
+  test("renders three menu item reviews correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/menuitemreviews/all")
+      .reply(200, menuItemReviewFixtures.threeMenuItemReviews);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("5");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "6",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "7",
+    );
+
+    const createMenuItemReviewsButton = screen.queryByText("Create MenuItemReviews");
+    expect(createMenuItemReviewsButton).not.toBeInTheDocument();
+
+    const itemId = screen.getByText("1");
+    expect(itemId).toBeInTheDocument();
+
+    const reviewerEmail = screen.getByText(
+      "cgaucho@ucsb.edu",
+    );
+    expect(reviewerEmail).toBeInTheDocument();
+
+    const stars = screen.getByText("3");
+    expect(stars).toBeInTheDocument();
+
+    const dateReviewed = screen.getByText("2025-04-28T21:28:44.426");
+    expect(dateReviewed).toBeInTheDocument();
+
+    const comments = screen.getByText(
+      "mac and cheese needs more cheese",
+    );
+    expect(comments).toBeInTheDocument();
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByTestId("MenuItemReviewTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("MenuItemReviewTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/menuitemreviews/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/menuitemreviews/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/menuitemreviews/all")
+      .reply(200, menuItemReviewFixtures.threeMenuItemReviews);
+      axiosMock
+      .onDelete("/api/menuitemreviews")
+      .reply(200, "Review with id 5 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "5",
+    );
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith("Review with id 5 was deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/menuitemreviews");
+    expect(axiosMock.history.delete[0].url).toBe("/api/menuitemreviews");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 5 });
   });
 });

--- a/frontend/src/tests/utils/menuItemReviewUtils.test.js
+++ b/frontend/src/tests/utils/menuItemReviewUtils.test.js
@@ -42,7 +42,7 @@ describe("menuItemReviewUtils", () => {
 
       // assert
       expect(result).toEqual({
-        url: "/api/menuItemReviews",
+        url: "/api/menuitemreviews",
         method: "DELETE",
         params: { id: 17 },
       });


### PR DESCRIPTION
closes #41

merge after #40

In this PR, we add the index page for the menuitemreviews

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/53443878-369b-49f4-ac37-02633977b1af" />


Deployed here: https://team02-timothytwu-dev.dokku-13.cs.ucsb.edu/
storybook: https://680e1b2465d1989bbc583612-kedateldid.chromatic.com/?path=/story/pages-menuitemreviews-menuitemreviewsindexpage--empty
- check by deleting existing reviews
- links toggle between add screen and edit screens (not yet done)